### PR TITLE
Retry `SendInput` after switching desktops upon initial failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Regardless, if you want a working and stable solution for crossplatform keyboard
 ## Limitations
 - Only keyboard and relative mouse events work (that is, can be forwarded to clients)
 - Clients only are supported on Windows, however, server support will be added in the future
+- When Windows UAC is active the client needs elevated privileges to function properly. You may need to run the client in the System account (e.g. `psexec -sid client ...`)
 
 ## Project structure
 - `server` - server application code


### PR DESCRIPTION
When Windows UAC is active, `SendInput` fails because "the UAC desktop
is in focus" (blocking events on the original desktop).

As a initial work around for this use case, the desktop is switched and
the `SendInput` is retried.

To be able to do this, the process needs to run with sufficient
privileges to access the UAC desktop.

There are several ways to do this.
One example is the `psexec` tool (you may need to use absolute paths -
even in the config):

```
psexec -sid client ...
```

I am not sure whether this simple "retry once" strategy is sufficient
or a more sophisticated approach is required.