### PR TITLE
cargo.toml tweaks for rpm build

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -27,4 +27,4 @@ package = "client"
 buildflags = ["--release"]
 
 [package.metadata.rpm.targets]
-client = { path = "/usr/bin/client" }
+client = { path = "/usr/bin/rkvm-client" }

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,5 +1,7 @@
 [package]
 name = "client"
+description = "A tool for sharing keyboard and mouse across multiple Linux and Windows machines, the client"
+license = "MIT"
 version = "0.2.0"
 authors = ["Jan Trefil <8711792+htrefil@users.noreply.github.com>"]
 edition = "2018"
@@ -17,3 +19,12 @@ log = "0.4.11"
 env_logger = "0.8.1"
 tokio-native-tls = "0.3.0"
 anyhow = "1.0.33"
+
+[package.metadata.rpm]
+package = "client"
+
+[package.metadata.rpm.cargo]
+buildflags = ["--release"]
+
+[package.metadata.rpm.targets]
+client = { path = "/usr/bin/client" }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,5 +1,7 @@
 [package]
 name = "server"
+description = "A tool for sharing keyboard and mouse across multiple Linux and Windows machines, the server"
+license = "MIT"
 version = "0.2.0"
 authors = ["Jan Trefil <8711792+htrefil@users.noreply.github.com>"]
 edition = "2018"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -19,3 +19,12 @@ log = "0.4.11"
 env_logger = "0.8.1"
 tokio-native-tls = "0.3.0"
 anyhow = "1.0.33"
+
+[package.metadata.rpm]
+package = "server"
+
+[package.metadata.rpm.cargo]
+buildflags = ["--release"]
+
+[package.metadata.rpm.targets]
+server = { path = "/usr/bin/rkvm-server" }


### PR DESCRIPTION
Minimal tweaks to the toml files to enable easy build on RPM distros with [cargo-rpm](https://github.com/iqlusioninc/cargo-rpm)
Tested on Fedora 35.