### PR TITLE
Workaround bindgen comment rusting bug

### DIFF
--- a/rkvm-input/Cargo.toml
+++ b/rkvm-input/Cargo.toml
@@ -19,3 +19,6 @@ thiserror = "1.0.40"
 [build-dependencies]
 bindgen = "0.65.1"
 pkg-config = "0.3.19"
+
+[lib]
+doctest = false


### PR DESCRIPTION
Currently the tests wont run on x86_64-linux on my machine due to a CXX comment being parsed by rustc due to improper conversion.

See more:
https://users.rust-lang.org/t/disable-doc-tests-for-bindgen-module/54639/2