### PR TITLE
Fix systemd services

### DIFF
--- a/systemd/rkvm-client.service
+++ b/systemd/rkvm-client.service
@@ -1,8 +1,9 @@
 [Unit]
 Description=rkvm client
+Wants=network-online.target
 After=network-online.target
 # This prevents systemd from giving up trying to restart the service.
-StartLimitBurst=0
+StartLimitIntervalSec=0
 
 [Service]
 ExecStart=/usr/bin/rkvm-client /etc/rkvm/client.toml

--- a/systemd/rkvm-server.service
+++ b/systemd/rkvm-server.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=rkvm server
-After=network-online.target
+After=network.target
 
 [Service]
 ExecStart=/usr/bin/rkvm-server /etc/rkvm/server.toml


### PR DESCRIPTION
- a server should be after network.target instead of network-online.target[1]
- a client should also pull in network-online.target[1]
- the manual mentions StartLimitIntervalSec=0 but not StartLimitBurst=0[2]

[1]: man systemd.special
[2]: man systemd.unit