### PR TITLE
Add support to `rkvm-server` for a new configuration option, `device-names`, which is an array that let's specify which input devices to register

### DIFF
--- a/example/server.toml
+++ b/example/server.toml
@@ -3,6 +3,9 @@ listen = "0.0.0.0:5258"
 switch-keys = ["left-alt", "left-ctrl"]
 certificate = "/etc/rkvm/certificate.pem"
 key = "/etc/rkvm/key.pem"
+# Specify the list of input devices to register in the following array,
+# or leave the array emtpy to register all detected input devices.
+device-names = []
 
 # This is to prevent malicious clients from connecting to the server.
 # Make sure this matches your client's config.

--- a/rkvm-server/src/config.rs
+++ b/rkvm-server/src/config.rs
@@ -12,6 +12,7 @@ pub struct Config {
     pub key: PathBuf,
     pub password: String,
     pub switch_keys: HashSet<SwitchKey>,
+    pub device_names: HashSet<String>,
 }
 
 #[derive(Deserialize, Clone, Copy, PartialEq, Eq, Hash)]

--- a/rkvm-server/src/main.rs
+++ b/rkvm-server/src/main.rs
@@ -68,9 +68,10 @@ async fn main() -> ExitCode {
     };
 
     let switch_keys = config.switch_keys.into_iter().map(Into::into).collect();
+    let device_names = config.device_names;
 
     tokio::select! {
-        result = server::run(config.listen, acceptor, &config.password, &switch_keys) => {
+        result = server::run(config.listen, acceptor, &config.password, &switch_keys, &device_names) => {
             if let Err(err) = result {
                 tracing::error!("Error: {}", err);
                 return ExitCode::FAILURE;

--- a/rkvm-server/src/server.rs
+++ b/rkvm-server/src/server.rs
@@ -38,6 +38,7 @@ pub async fn run(
     acceptor: TlsAcceptor,
     password: &str,
     switch_keys: &HashSet<Key>,
+    device_names: &HashSet<String>,
 ) -> Result<(), Error> {
     let listener = TcpListener::bind(&listen).await.map_err(Error::Network)?;
     tracing::info!("Listening on {}", listen);
@@ -109,72 +110,87 @@ pub async fn run(
                 let abs = interceptor.abs().collect::<HashMap<_,_>>();
                 let keys = interceptor.key().collect::<HashSet<_>>();
 
-                for (_, (sender, _)) in &clients {
-                    let update = Update::CreateDevice {
-                        id,
-                        name: name.clone(),
-                        version: version.clone(),
-                        vendor: vendor.clone(),
-                        product: product.clone(),
-                        rel: rel.clone(),
-                        abs: abs.clone(),
-                        keys: keys.clone(),
-                    };
+                let mut register_input_device = false;
 
-                    let _ = sender.send(update).await;
+                if device_names.len() > 0 {
+                    for device_name in device_names {
+                        if name.to_str().unwrap().contains(device_name) {
+                            register_input_device = true;
+                            break;
+                        }
+                    }
+                } else {
+                    register_input_device = true;
                 }
 
-                let (interceptor_sender, mut interceptor_receiver) = mpsc::channel(32);
-                devices.insert(Device {
-                    name,
-                    version,
-                    vendor,
-                    product,
-                    rel,
-                    abs,
-                    keys,
-                    sender: interceptor_sender,
-                });
+                if register_input_device {
+                    for (_, (sender, _)) in &clients {
+                        let update = Update::CreateDevice {
+                            id,
+                            name: name.clone(),
+                            version: version.clone(),
+                            vendor: vendor.clone(),
+                            product: product.clone(),
+                            rel: rel.clone(),
+                            abs: abs.clone(),
+                            keys: keys.clone(),
+                        };
 
-                let events_sender = events_sender.clone();
-                tokio::spawn(async move {
-                    loop {
-                        tokio::select! {
-                            event = interceptor.read() => {
-                                if event.is_err() | events_sender.send((id, event)).await.is_err() {
-                                    break;
-                                }
-                            }
-                            event = interceptor_receiver.recv() => {
-                                let event = match event {
-                                    Some(event) => event,
-                                    None => break,
-                                };
+                        let _ = sender.send(update).await;
+                    }
 
-                                match interceptor.write(&event).await {
-                                    Ok(()) => {},
-                                    Err(err) => {
-                                        let _ = events_sender.send((id, Err(err))).await;
+                    let (interceptor_sender, mut interceptor_receiver) = mpsc::channel(32);
+                    devices.insert(Device {
+                        name,
+                        version,
+                        vendor,
+                        product,
+                        rel,
+                        abs,
+                        keys,
+                        sender: interceptor_sender,
+                    });
+
+                    let events_sender = events_sender.clone();
+                    tokio::spawn(async move {
+                        loop {
+                            tokio::select! {
+                                event = interceptor.read() => {
+                                    if event.is_err() | events_sender.send((id, event)).await.is_err() {
                                         break;
                                     }
                                 }
+                                event = interceptor_receiver.recv() => {
+                                    let event = match event {
+                                        Some(event) => event,
+                                        None => break,
+                                    };
 
-                                tracing::trace!(id = %id, "Wrote an event to device");
+                                    match interceptor.write(&event).await {
+                                        Ok(()) => {},
+                                        Err(err) => {
+                                            let _ = events_sender.send((id, Err(err))).await;
+                                            break;
+                                        }
+                                    }
+
+                                    tracing::trace!(id = %id, "Wrote an event to device");
+                                }
                             }
                         }
-                    }
-                });
+                    });
 
-                let device = &devices[id];
+                    let device = &devices[id];
 
-                tracing::info!(
-                    id = %id,
-                    name = ?device.name,
-                    vendor = %device.vendor,
-                    product = %device.product,
-                    version = %device.version,
-                    "Registered new device"
-                );
+                    tracing::info!(
+                        id = %id,
+                        name = ?device.name,
+                        vendor = %device.vendor,
+                        product = %device.product,
+                        version = %device.version,
+                        "Registered new device"
+                    );
+                }
             }
             (id, result) = event => match result {
                 Ok(event) => {


### PR DESCRIPTION
Add support to `rkvm-server` for a new configuration option, `device-names`, which is an array that let's specify which input devices to register, to the `server.toml` configuration file.

Leaving the array empty, e.g., `device-names = []`, means that rkvm will register all detected input devices, which is the same as the current default behavior.

Users can specify partial name of the device to register. For example, the `device-names = ["BenQ Mouse", "Logitech"]` option will match and register the devices which have name "Logitech Keyboard" and "Logitech Mouse".

The motivation behind this pull request came from the fact that, because currently `rkvm-server` registers all input devices it finds on the server, sometimes it registers input devices that users might not want to share between machines, e.g., a gamepad, or a stylus. 

This feature is also useful as a "workaround" for devices which do not play nice with rkvm for one reason or another. (I have one gamepad which, if `rkvm-server` is running and registered the gamepad, will slow all input from the gamepad to a crawl. Using the feature in this pull request to make rkvm not register the gamepad "fix" the problem completely).

I've been using my own fork of rkvm which has these changes for a couple of days, and things seem to be working fine.
However, I'm quite new to Rust in general, so please excuse any mistakes, and please don't hesitate to tell me to fix any mistakes that you find.

And, lastly, thank you for rkvm. It's a great little program that makes me life better. :)