### PR TITLE
feat(server): Add device allowlist

### DIFF
--- a/example/server-with-allowlist.toml
+++ b/example/server-with-allowlist.toml
@@ -1,0 +1,27 @@
+listen = "0.0.0.0:5258"
+# See `switch-keys.md` in the repository root for the list of all possible keys.
+switch-keys = ["left-alt", "left-ctrl"]
+# Whether switch key presses should be propagated on the server and its clients.
+# Optional, defaults to true.
+# propagate-switch-keys = true
+certificate = "/etc/rkvm/certificate.pem"
+key = "/etc/rkvm/key.pem"
+
+# This is to prevent malicious clients from connecting to the server.
+# Make sure this matches your client's config.
+#
+# Change this to your own value before deploying rkvm.
+password = "123456789"
+
+# A device must match one of the listed devices to be forwarded
+#
+# Filling out all fields means all fields must match exactly for it to be
+# considered a match
+[[device-allowlist]]
+name = "device name"
+vendor-id = 123
+product-id = 456
+
+# Filling out only one field means it must match, and the others are not checked
+[[device-allowlist]]
+vendor-id = 7

--- a/rkvm-input/src/device.rs
+++ b/rkvm-input/src/device.rs
@@ -1,0 +1,42 @@
+use serde::Deserialize;
+
+/// Describes parts of a device
+#[derive(Deserialize, Clone)]
+#[serde(rename_all = "kebab-case")]
+pub struct DeviceSpec {
+    pub name: Option<std::ffi::CString>,
+    pub vendor_id: Option<u16>,
+    pub product_id: Option<u16>,
+}
+
+impl DeviceSpec {
+    /// Compares the given values to this DeviceSpec
+    ///
+    /// A None value means we skip that comparison
+    pub fn matches(
+        &self,
+        other_name: &std::ffi::CStr,
+        other_vendor_id: &u16,
+        other_product_id: &u16,
+    ) -> bool {
+        if let Some(name) = &self.name {
+            if name.as_c_str() != other_name {
+                return false;
+            }
+        }
+
+        if let Some(vendor_id) = &self.vendor_id {
+            if vendor_id != other_vendor_id {
+                return false;
+            }
+        }
+
+        if let Some(product_id) = &self.product_id {
+            if product_id != other_product_id {
+                return false;
+            }
+        }
+
+        true
+    }
+}

--- a/rkvm-input/src/evdev.rs
+++ b/rkvm-input/src/evdev.rs
@@ -1,5 +1,6 @@
 use crate::glue::{self, libevdev};
 
+use std::ffi::CStr;
 use std::fs::File;
 use std::io::{Error, ErrorKind};
 use std::mem::MaybeUninit;
@@ -49,6 +50,25 @@ impl Evdev {
             evdev,
             file: Some(file),
         })
+    }
+
+    pub fn name(&self) -> &CStr {
+        let name = unsafe { glue::libevdev_get_name(self.as_ptr()) };
+        let name = unsafe { CStr::from_ptr(name) };
+
+        name
+    }
+
+    pub fn vendor(&self) -> u16 {
+        unsafe { glue::libevdev_get_id_vendor(self.as_ptr()) as _ }
+    }
+
+    pub fn product(&self) -> u16 {
+        unsafe { glue::libevdev_get_id_product(self.as_ptr()) as _ }
+    }
+
+    pub fn version(&self) -> u16 {
+        unsafe { glue::libevdev_get_id_version(self.as_ptr()) as _ }
     }
 
     pub fn file(&self) -> Option<&AsyncFd<File>> {

--- a/rkvm-input/src/interceptor.rs
+++ b/rkvm-input/src/interceptor.rs
@@ -107,22 +107,19 @@ impl Interceptor {
     }
 
     pub fn name(&self) -> &CStr {
-        let name = unsafe { glue::libevdev_get_name(self.evdev.as_ptr()) };
-        let name = unsafe { CStr::from_ptr(name) };
-
-        name
+        self.evdev.name()
     }
 
     pub fn vendor(&self) -> u16 {
-        unsafe { glue::libevdev_get_id_vendor(self.evdev.as_ptr()) as _ }
+        self.evdev.vendor()
     }
 
     pub fn product(&self) -> u16 {
-        unsafe { glue::libevdev_get_id_product(self.evdev.as_ptr()) as _ }
+        self.evdev.product()
     }
 
     pub fn version(&self) -> u16 {
-        unsafe { glue::libevdev_get_id_version(self.evdev.as_ptr()) as _ }
+        self.evdev.version()
     }
 
     pub fn rel(&self) -> RelCaps {

--- a/rkvm-input/src/interceptor.rs
+++ b/rkvm-input/src/interceptor.rs
@@ -4,6 +4,7 @@ pub use caps::{AbsCaps, KeyCaps, RelCaps, Repeat};
 
 use crate::abs::{AbsAxis, AbsEvent, ToolType};
 use crate::convert::Convert;
+use crate::device::DeviceSpec;
 use crate::evdev::Evdev;
 use crate::event::Event;
 use crate::glue;
@@ -177,9 +178,28 @@ impl Interceptor {
         }
     }
 
-    #[tracing::instrument(skip(registry))]
-    pub(crate) async fn open(path: &Path, registry: &Registry) -> Result<Self, OpenError> {
+    #[tracing::instrument(skip(registry, device_allowlist))]
+    pub(crate) async fn open(
+        path: &Path,
+        registry: &Registry,
+        device_allowlist: &[DeviceSpec],
+    ) -> Result<Self, OpenError> {
         let evdev = Evdev::open(path).await?;
+
+        // An empty allowlist means we allow all devices
+        if !device_allowlist.is_empty() {
+            let name = evdev.name();
+            let vendor_id = evdev.vendor();
+            let product_id = evdev.product();
+
+            if !device_allowlist
+                .iter()
+                .any(|check| check.matches(&name, &vendor_id, &product_id))
+            {
+                return Err(OpenError::NotMatchingAllowlist);
+            }
+        }
+
         let metadata = evdev.file().unwrap().get_ref().metadata()?;
 
         let reader_handle = registry
@@ -276,6 +296,8 @@ unsafe impl Send for Interceptor {}
 pub(crate) enum OpenError {
     #[error("Not appliable")]
     NotAppliable,
+    #[error("Device doesn't match allowlist")]
+    NotMatchingAllowlist,
     #[error(transparent)]
     Io(#[from] Error),
 }

--- a/rkvm-input/src/lib.rs
+++ b/rkvm-input/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod abs;
+pub mod device;
 pub mod event;
 pub mod interceptor;
 pub mod key;

--- a/rkvm-input/src/registry.rs
+++ b/rkvm-input/src/registry.rs
@@ -49,6 +49,7 @@ pub struct Handle {
 
 impl Drop for Handle {
     fn drop(&mut self) {
+        tracing::trace!("Dropping {:?}", self.entry);
         assert!(self.entries.lock().unwrap().remove(&self.entry));
     }
 }

--- a/rkvm-server/src/config.rs
+++ b/rkvm-server/src/config.rs
@@ -1,3 +1,4 @@
+use rkvm_input::device::DeviceSpec;
 use rkvm_input::key::{Button, Key, Keyboard};
 use serde::Deserialize;
 use std::collections::HashSet;
@@ -13,6 +14,8 @@ pub struct Config {
     pub password: String,
     pub switch_keys: HashSet<SwitchKey>,
     pub propagate_switch_keys: Option<bool>,
+    #[serde(default)]
+    pub device_allowlist: Vec<DeviceSpec>,
 }
 
 #[derive(Deserialize, Clone, Copy, PartialEq, Eq, Hash)]
@@ -1234,6 +1237,12 @@ mod test {
     #[test]
     fn example_parses() {
         let config = include_str!("../../example/server.toml");
+        toml::from_str::<Config>(config).unwrap();
+    }
+
+    #[test]
+    fn example_with_allowlist_parses() {
+        let config = include_str!("../../example/server-with-allowlist.toml");
         toml::from_str::<Config>(config).unwrap();
     }
 }

--- a/rkvm-server/src/main.rs
+++ b/rkvm-server/src/main.rs
@@ -71,7 +71,7 @@ async fn main() -> ExitCode {
     let propagate_switch_keys = config.propagate_switch_keys.unwrap_or(true);
 
     tokio::select! {
-        result = server::run(config.listen, acceptor, &config.password, &switch_keys, propagate_switch_keys) => {
+        result = server::run(config.listen, acceptor, &config.password, &switch_keys, propagate_switch_keys, config.device_allowlist) => {
             if let Err(err) = result {
                 tracing::error!("Error: {}", err);
                 return ExitCode::FAILURE;

--- a/rkvm-server/src/server.rs
+++ b/rkvm-server/src/server.rs
@@ -1,4 +1,5 @@
 use rkvm_input::abs::{AbsAxis, AbsInfo};
+use rkvm_input::device::DeviceSpec;
 use rkvm_input::event::Event;
 use rkvm_input::key::{Key, KeyEvent};
 use rkvm_input::monitor::Monitor;
@@ -39,11 +40,12 @@ pub async fn run(
     password: &str,
     switch_keys: &HashSet<Key>,
     propagate_switch_keys: bool,
+    device_allowlist: Vec<DeviceSpec>,
 ) -> Result<(), Error> {
     let listener = TcpListener::bind(&listen).await.map_err(Error::Network)?;
     tracing::info!("Listening on {}", listen);
 
-    let mut monitor = Monitor::new();
+    let mut monitor = Monitor::new(device_allowlist);
     let mut devices = Slab::<Device>::new();
     let mut clients = Slab::<(Sender<_>, SocketAddr)>::new();
     let mut current = 0;


### PR DESCRIPTION
This PR is meant as a spiritual continuation of #55, implemented by using the evdev attributes instead of file paths. I'm doing the comparison inside Inspector to ensure we stop processing a device as soon as possible (i.e. before we create a writer for the device)

The default behaviour with `device-allowlist` unset is the same as before: All inputs found will be forwarded
If you configure the device-allowlist, only the devices matching at least 1 of the config options will be forwarded


### Example configs
```toml
# Only forward Logitech devices

[[device-allowlist]]
vendor-id = 1133
```

```toml
# Forward Logitech & UHK V1 devices

[[device-allowlist]]
name = "Ultimate Gadget Laboratories UHK 60 v1"

[[device-allowlist]]
vendor-id = 1133
```

I currently support `name`, `vendor-id`, and `product-id` for filtering, and they're all either exact matches if they're set, or no check at all if they're unset.
Happy to change things as you see fit!